### PR TITLE
Upgrade to "include_tasks"

### DIFF
--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -4,12 +4,13 @@ galaxy_info:
   description: Role for setting up docker-friendly firewall
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: 2.16
 
   platforms:
     - name: Ubuntu
       versions:
         - 22.04
+        - 24.04
 
   galaxy_tags:
     - docker

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -15,5 +15,4 @@
     dff: "{{ dff_defaults | combine(docker.firewall | default({})) }}"
 
 - name: Setup DFF
-  become: true
   ansible.builtin.include_tasks: setup_firewall.yaml

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -16,4 +16,4 @@
 
 - name: Setup DFF
   become: true
-  include: setup_firewall.yaml
+  ansible.builtin.include_tasks: setup_firewall.yaml

--- a/tasks/setup_firewall.yaml
+++ b/tasks/setup_firewall.yaml
@@ -1,4 +1,5 @@
 - name: Render DFF-unit file
+  become: true
   ansible.builtin.template:
     src: service.j2
     dest: /etc/systemd/system/docker-friendly-firewall.service
@@ -9,16 +10,19 @@
   register: render_unit
 
 - name: Reload systemd
+  become: true
   ansible.builtin.systemd:
     daemon_reload: true
   when: render_unit.changed
 
 - name: Enable DFF
+  become: true
   ansible.builtin.service:
     name: docker-friendly-firewall.service
     enabled: true
 
 - name: Configure DFF-directory
+  become: true
   ansible.builtin.file:
     path: /opt/docker-friendly-firewall
     state: directory
@@ -27,6 +31,7 @@
     mode: "0555"
 
 - name: Render DFF-scripts
+  become: true
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"


### PR DESCRIPTION
> ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.